### PR TITLE
Add adhoc satellite functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ class getDisplay(Resource):
         sats = None
         key = None
         if request.args:
-            key = request.args.get('key', 0)
+            key = request.args.get('key', None)
             sats = request.args.get('satellites', None)
             if sats:
                 sats = sats.split(',')

--- a/functions.py
+++ b/functions.py
@@ -320,7 +320,7 @@ def getN2Y0sat(satId, n2yokey):
     df.columns= ['lat', 'lon', 'satName']
     return df
 
-def getChart(n2yokey, adhoc):
+def getChart(n2yokey= None, adhoc=None):
     userLat = 35 
     height = 500
     width = height*2


### PR DESCRIPTION
-changed getN2Y0sat() to preserve satellite name in column with returned DataFrame
-changed getChart() to accept list of adhoc satellites, chart them and add them to a separate legend.
-changed getChart() to just show ISS and not HST and USA224 if n2yo key is not provided
-changed app.py to split url query parameter if list of adhoc sats are requested